### PR TITLE
IMS-5: Create PR template for all projects

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+### Description
+
+(Provide context and explain why you are making the change you are making, and why it is the right one)
+
+### Medias (if needed)
+
+(Provide images or videos about the changes)
+
+### Related ticket
+
+Ticket: [PR Title](https://developer-solutions.atlassian.net/browse/IMS-XXX)
+
+### Testplan
+
+- [ ] I tested this change on my local environment.
+- [ ] I ran the project using multiple simulators in Xcode.
+- [ ] I ran the project using Real device (if applicable).
+- [ ] I ran the unit tests.
+- [ ] I requested this endpoint on Postman (if applicable).
+- [ ] I requested this endpoint on Swagger documentation (if applicable).
+
+### Checklist
+
+- [ ] I added tests for this change.
+- [ ] I checked the code style and run the linter.
+- [ ] I added necessary documentation (if applicable).
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+### Related ticket
+
+Ticket: [PR Title](https://developer-solutions.atlassian.net/browse/IMS-XXX)
+
 ### Description
 
 (Provide context and explain why you are making the change you are making, and why it is the right one)
@@ -5,10 +9,6 @@
 ### Medias (if needed)
 
 (Provide images or videos about the changes)
-
-### Related ticket
-
-Ticket: [PR Title](https://developer-solutions.atlassian.net/browse/IMS-XXX)
 
 ### Testplan
 


### PR DESCRIPTION
### Related ticket

Ticket: [IMS-5: Create PR template for all projects](https://developer-solutions.atlassian.net/browse/IMS-5)

### Description

This PR added the Pull request template in `.github` directory.

### Medias (if needed)

![image](https://github.com/user-attachments/assets/7c05b0b9-0d18-44a7-a8ac-11ddf013c885)

### Testplan

- [ ] I tested this change on my local environment.
- [ ] I ran the project using multiple simulators in Xcode.
- [ ] I ran the project using Real device (if applicable).
- [ ] I ran the unit tests.
- [ ] I requested this endpoint on Postman (if applicable).
- [ ] I requested this endpoint on Swagger documentation (if applicable).

### Checklist

- [ ] I added tests for this change.
- [ ] I checked the code style and run the linter.
- [ ] I added necessary documentation (if applicable).