### PR TITLE
IMS-38: Create endpoint to fetch all products

### DIFF
--- a/ims-backend/src/apps/core/di/Container.ts
+++ b/ims-backend/src/apps/core/di/Container.ts
@@ -12,6 +12,9 @@ import CreateProductService from '../../ims/api/application/products/CreateProdu
 import ProductCreator from '../../ims/api/infrastructure/products/ProductCreator';
 import PrismaProductRepository from '../../ims/api/infrastructure/products/repositories/PrismaProductRepository';
 import CreateProductController from '../../ims/api/infrastructure/express/controllers/products/CreateProductController';
+import ProductFetcher from '../../ims/api/infrastructure/products/ProductFetcher';
+import FetchProductService from '../../ims/api/application/products/FetchProductService';
+import FetchProductController from '../../ims/api/infrastructure/express/controllers/products/FetchProductController';
 
 export default class Container {
   private readonly container: AwilixContainer;
@@ -45,9 +48,12 @@ export default class Container {
       })
       .register({
         createProductService: asClass(CreateProductService).singleton(),
+        fetchProductService: asClass(FetchProductService).singleton(),
         productCreator: asClass(ProductCreator).singleton(),
+        productFetcher: asClass(ProductFetcher).singleton(),
         productRepository: asClass(PrismaProductRepository).singleton(),
         createProductController: asClass(CreateProductController).singleton(),
+        fetchProductController: asClass(FetchProductController).singleton(),
       });
   }
 

--- a/ims-backend/src/apps/core/routes/api/products.route.ts
+++ b/ims-backend/src/apps/core/routes/api/products.route.ts
@@ -1,10 +1,14 @@
 import { Express } from 'express';
 import Container from '../../di/Container';
 import CreateProductController from '../../../ims/api/infrastructure/express/controllers/products/CreateProductController';
+import FetchProductController from '../../../ims/api/infrastructure/express/controllers/products/FetchProductController';
 
 export const register = function (app: Express): void {
-  const controller: CreateProductController = new Container()
-    .invoke()
-    .resolve<CreateProductController>('createProductController');
-  app.post('/products', controller.rules, controller.invoke.bind(controller));
+  const container = new Container().invoke();
+  const fetchController: FetchProductController = container.resolve<FetchProductController>('fetchProductController');
+  const createController: CreateProductController =
+    container.resolve<CreateProductController>('createProductController');
+
+  app.get('/products', fetchController.rules, fetchController.invoke.bind(fetchController));
+  app.post('/products', createController.rules, createController.invoke.bind(createController));
 };

--- a/ims-backend/src/apps/ims/api/application/products/FetchProductService.ts
+++ b/ims-backend/src/apps/ims/api/application/products/FetchProductService.ts
@@ -1,0 +1,19 @@
+import { Fetcher } from '../../../shared/domain/Fetcher';
+import { Logger } from '../../../shared/domain/Logger';
+import { Product } from '../../domain/models/products/Product';
+
+export type FetchProductResponse = {
+  data: Product[];
+};
+
+export default class FetchProductService {
+  constructor(
+    private readonly logger: Logger,
+    private readonly productFetcher: Fetcher,
+  ) {}
+
+  async invoke(): Promise<FetchProductResponse> {
+    this.logger.info('Fetching products');
+    return await this.productFetcher.invoke();
+  }
+}

--- a/ims-backend/src/apps/ims/api/infrastructure/express/controllers/products/FetchProductController.ts
+++ b/ims-backend/src/apps/ims/api/infrastructure/express/controllers/products/FetchProductController.ts
@@ -1,0 +1,20 @@
+import { NextFunction, Request, Response } from 'express';
+import status from 'http-status';
+import { Controller } from '../../../../../shared/infrastructure/express/controllers/Controller';
+import { ErrorHandler } from '../../../../../shared/domain/ErrorHandler';
+import FetchProductService, { FetchProductResponse } from '../../../../application/products/FetchProductService';
+
+export default class FetchProductController implements Controller {
+  constructor(private readonly fetchProductService: FetchProductService) {}
+
+  async invoke(_: Request, response: Response, next: NextFunction): Promise<Response | void> {
+    try {
+      const productResponse: FetchProductResponse = await this.fetchProductService.invoke();
+      return response.json(productResponse).status(status.OK);
+    } catch (error) {
+      const { message } = error as Error;
+      const errorHandler = new ErrorHandler(message, status.INTERNAL_SERVER_ERROR);
+      next(response.json(errorHandler.toJson()));
+    }
+  }
+}

--- a/ims-backend/src/apps/ims/api/infrastructure/products/ProductFetcher.ts
+++ b/ims-backend/src/apps/ims/api/infrastructure/products/ProductFetcher.ts
@@ -1,0 +1,15 @@
+import { Product } from '@prisma/client';
+import { Fetcher } from '../../../shared/domain/Fetcher';
+import { CrudRepository } from '../../../shared/domain/models/repository/CrudRepository';
+import { FetchProductResponse } from '../../application/products/FetchProductService';
+
+export default class ProductFetcher implements Fetcher {
+  constructor(private readonly productRepository: CrudRepository<FetchProductResponse, Product>) {}
+
+  async invoke(): Promise<FetchProductResponse> {
+    const products = await this.productRepository.findAll();
+    return {
+      data: products,
+    };
+  }
+}

--- a/ims-backend/src/apps/ims/shared/domain/Fetcher.ts
+++ b/ims-backend/src/apps/ims/shared/domain/Fetcher.ts
@@ -1,0 +1,5 @@
+import { FetchProductResponse } from '../../api/application/products/FetchProductService';
+
+export interface Fetcher {
+  invoke(): Promise<FetchProductResponse>;
+}


### PR DESCRIPTION
### Related ticket

Ticket: [IMS-38: Create endpoint to fetch all products](https://developer-solutions.atlassian.net/browse/IMS-38)

### Description

This PR added the endpoint to fetch all products.

### Medias (if needed)

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/d008b32d-19ce-410c-9d2f-47096a3db129">

### Testplan

- [x] I tested this change on my local environment.
- [ ] I ran the project using multiple simulators in Xcode.
- [ ] I ran the project using Real device (if applicable).
- [ ] I ran the unit tests.
- [x] I requested this endpoint on Postman (if applicable).
- [ ] I requested this endpoint on Swagger documentation (if applicable).

### Checklist

- [ ] I added tests for this change.
- [x] I checked the code style and run the linter.
- [ ] I added necessary documentation (if applicable).

