### PR TITLE
IMS-40: Create endpoint to supply products stock

### DIFF
--- a/ims-backend/src/apps/core/di/Container.ts
+++ b/ims-backend/src/apps/core/di/Container.ts
@@ -18,6 +18,9 @@ import FetchProductController from '../../ims/api/infrastructure/express/control
 import RemoveProductService from '../../ims/api/application/products/RemoveProductService';
 import ProductRemover from '../../ims/api/infrastructure/products/ProductRemover';
 import RemoveProductController from '../../ims/api/infrastructure/express/controllers/products/RemoveProductController';
+import SupplyProductController from '../../ims/api/infrastructure/express/controllers/products/SupplyProductController';
+import ProductSupplier from '../../ims/api/infrastructure/products/ProductSupplier';
+import SupplyProductService from '../../ims/api/application/products/SupplyProductService';
 
 export default class Container {
   private readonly container: AwilixContainer;
@@ -53,13 +56,16 @@ export default class Container {
         createProductService: asClass(CreateProductService).singleton(),
         fetchProductService: asClass(FetchProductService).singleton(),
         removeProductService: asClass(RemoveProductService).singleton(),
+        supplyProductService: asClass(SupplyProductService).singleton(),
         productCreator: asClass(ProductCreator).singleton(),
         productFetcher: asClass(ProductFetcher).singleton(),
         productRemover: asClass(ProductRemover).singleton(),
+        productSupplier: asClass(ProductSupplier).singleton(),
         productRepository: asClass(PrismaProductRepository).singleton(),
         createProductController: asClass(CreateProductController).singleton(),
         fetchProductController: asClass(FetchProductController).singleton(),
         removeProductController: asClass(RemoveProductController).singleton(),
+        supplyProductController: asClass(SupplyProductController).singleton(),
       });
   }
 

--- a/ims-backend/src/apps/core/routes/api/products.route.ts
+++ b/ims-backend/src/apps/core/routes/api/products.route.ts
@@ -3,6 +3,7 @@ import Container from '../../di/Container';
 import CreateProductController from '../../../ims/api/infrastructure/express/controllers/products/CreateProductController';
 import FetchProductController from '../../../ims/api/infrastructure/express/controllers/products/FetchProductController';
 import RemoveProductController from '../../../ims/api/infrastructure/express/controllers/products/RemoveProductController';
+import SupplyProductController from '../../../ims/api/infrastructure/express/controllers/products/SupplyProductController';
 
 export const register = function (app: Express): void {
   const container = new Container().invoke();
@@ -11,8 +12,11 @@ export const register = function (app: Express): void {
     container.resolve<CreateProductController>('createProductController');
   const removeController: RemoveProductController =
     container.resolve<RemoveProductController>('removeProductController');
+  const supplyController: SupplyProductController =
+    container.resolve<SupplyProductController>('supplyProductController');
 
   app.get('/products', fetchController.invoke.bind(fetchController));
   app.post('/products', createController.rules, createController.invoke.bind(createController));
+  app.put('/products', supplyController.rules, supplyController.invoke.bind(supplyController));
   app.delete('/products', removeController.rules, removeController.invoke.bind(removeController));
 };

--- a/ims-backend/src/apps/ims/api/application/products/SupplyProductService.ts
+++ b/ims-backend/src/apps/ims/api/application/products/SupplyProductService.ts
@@ -1,0 +1,26 @@
+import { Logger } from 'winston';
+import { Supplier } from '../../domain/products/Supplier';
+import { Product } from '../../domain/models/products/Product';
+
+export type SupplyProductRequest = {
+  id: number;
+  stock: number;
+};
+
+export type SupplyProductResponse = {
+  message: string;
+  code: number;
+  data: Product;
+};
+
+export default class SupplyProductService {
+  constructor(
+    private readonly logger: Logger,
+    private readonly productSupplier: Supplier,
+  ) {}
+
+  public async invoke(request: SupplyProductRequest): Promise<SupplyProductResponse> {
+    this.logger.info(`Supplying product: ${request.id}`);
+    return await this.productSupplier.invoke(request);
+  }
+}

--- a/ims-backend/src/apps/ims/api/domain/models/products/repositories/ProductRepository.ts
+++ b/ims-backend/src/apps/ims/api/domain/models/products/repositories/ProductRepository.ts
@@ -1,0 +1,5 @@
+import { Product } from '../Product';
+
+export interface ProductRepository {
+  supply(id: number, stock: number): Promise<Product>;
+}

--- a/ims-backend/src/apps/ims/api/domain/products/Supplier.ts
+++ b/ims-backend/src/apps/ims/api/domain/products/Supplier.ts
@@ -1,0 +1,5 @@
+import { SupplyProductRequest, SupplyProductResponse } from '../../application/products/SupplyProductService';
+
+export interface Supplier {
+  invoke(request: SupplyProductRequest): Promise<SupplyProductResponse>;
+}

--- a/ims-backend/src/apps/ims/api/infrastructure/express/controllers/products/SupplyProductController.ts
+++ b/ims-backend/src/apps/ims/api/infrastructure/express/controllers/products/SupplyProductController.ts
@@ -1,0 +1,33 @@
+import { NextFunction, Request, Response } from 'express';
+import { body } from 'express-validator';
+import status from 'http-status';
+import { Controller } from '../../../../../shared/infrastructure/express/controllers/Controller';
+import { RequestValidator } from '../../../../../shared/infrastructure/express/RequestValidator';
+import { ErrorHandler } from '../../../../../shared/domain/ErrorHandler';
+import SupplyProductService, {
+  SupplyProductRequest,
+  SupplyProductResponse,
+} from '../../../../application/products/SupplyProductService';
+
+export default class SupplyProductController implements Controller {
+  public readonly rules = [
+    body('id').isNumeric().withMessage('Please give a valid id'),
+    body('stock').isNumeric().withMessage('Please give a valid stock'),
+    RequestValidator,
+  ];
+
+  constructor(private readonly supplyProductService: SupplyProductService) {}
+
+  async invoke(request: Request, response: Response, next: NextFunction): Promise<Response | void> {
+    try {
+      const productData = request.body as SupplyProductRequest;
+      const productResponse: SupplyProductResponse = await this.supplyProductService.invoke(productData);
+
+      return response.json(productResponse).status(status.OK);
+    } catch (error) {
+      const { message } = error as Error;
+      const errorHandler = new ErrorHandler(message, status.INTERNAL_SERVER_ERROR);
+      next(response.json(errorHandler.toJson()));
+    }
+  }
+}

--- a/ims-backend/src/apps/ims/api/infrastructure/products/ProductSupplier.ts
+++ b/ims-backend/src/apps/ims/api/infrastructure/products/ProductSupplier.ts
@@ -1,0 +1,18 @@
+import httpStatus from 'http-status';
+import { SupplyProductRequest, SupplyProductResponse } from '../../application/products/SupplyProductService';
+import { ProductRepository } from '../../domain/models/products/repositories/ProductRepository';
+import { Supplier } from '../../domain/products/Supplier';
+import { Product } from '../../domain/models/products/Product';
+
+export default class ProductSupplier implements Supplier {
+  constructor(private readonly productRepository: ProductRepository) {}
+
+  async invoke(request: SupplyProductRequest): Promise<SupplyProductResponse> {
+    const product: Product = await this.productRepository.supply(request.id, request.stock);
+    return {
+      message: 'Product supplied',
+      code: httpStatus.OK,
+      data: product,
+    };
+  }
+}

--- a/ims-backend/src/apps/ims/api/infrastructure/products/repositories/PrismaProductRepository.ts
+++ b/ims-backend/src/apps/ims/api/infrastructure/products/repositories/PrismaProductRepository.ts
@@ -2,8 +2,9 @@ import { PrismaClient } from '@prisma/client';
 import { CrudRepository } from '../../../../shared/domain/models/repository/CrudRepository';
 import { Product } from '../../../domain/models/products/Product';
 import { ProductRequest } from '../../../application/products/CreateProductService';
+import { ProductRepository } from '../../../domain/models/products/repositories/ProductRepository';
 
-export default class PrismaProductRepository implements CrudRepository<ProductRequest, Product> {
+export default class PrismaProductRepository implements ProductRepository, CrudRepository<ProductRequest, Product> {
   constructor(private readonly database: PrismaClient) {}
 
   async findAll(): Promise<Product[]> {
@@ -45,6 +46,19 @@ export default class PrismaProductRepository implements CrudRepository<ProductRe
     await this.database.product.delete({
       where: {
         id,
+      },
+    });
+  }
+
+  async supply(id: number, stock: number): Promise<Product> {
+    return await this.database.product.update({
+      where: {
+        id,
+      },
+      data: {
+        stock: {
+          increment: stock,
+        },
       },
     });
   }


### PR DESCRIPTION
### Related ticket

Ticket: [IMS-40: Create endpoint to supply products stock](https://developer-solutions.atlassian.net/browse/IMS-40)

### Description

This PR added the endpoint to supply product stock.

- Added the `Supplier` service.

### Medias (if needed)

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/d3236eb9-4e3f-47a4-909b-62fcb1cfc9ec">

### Testplan

- [x] I tested this change on my local environment.
- [ ] I ran the project using multiple simulators in Xcode.
- [ ] I ran the project using Real device (if applicable).
- [ ] I ran the unit tests.
- [x] I requested this endpoint on Postman (if applicable).
- [ ] I requested this endpoint on Swagger documentation (if applicable).

### Checklist

- [ ] I added tests for this change.
- [x] I checked the code style and run the linter.
- [ ] I added necessary documentation (if applicable).

