### PR TITLE
IMS-41: Create endpoint to change password

### DIFF
--- a/ims-backend/src/apps/core/di/Container.ts
+++ b/ims-backend/src/apps/core/di/Container.ts
@@ -21,6 +21,9 @@ import RemoveProductController from '../../ims/api/infrastructure/express/contro
 import SupplyProductController from '../../ims/api/infrastructure/express/controllers/products/SupplyProductController';
 import ProductSupplier from '../../ims/api/infrastructure/products/ProductSupplier';
 import SupplyProductService from '../../ims/api/application/products/SupplyProductService';
+import CredentialsPasswordUpdater from '../../ims/api/infrastructure/authentication/credentials/CredentialsPasswordUpdater';
+import UpdatePasswordService from '../../ims/api/application/authentication/UpdatePasswordService';
+import UpdatePasswordController from '../../ims/api/infrastructure/express/controllers/UpdatePasswordController';
 
 export default class Container {
   private readonly container: AwilixContainer;
@@ -51,6 +54,9 @@ export default class Container {
         authenticationRepository: asClass(PrismaAuthenticationRepository).singleton(),
         authenticationService: asClass(AuthenticationService).singleton(),
         authenticationController: asClass(AuthenticationController).singleton(),
+        passwordUpdater: asClass(CredentialsPasswordUpdater).singleton(),
+        updatePasswordService: asClass(UpdatePasswordService).singleton(),
+        updatePasswordController: asClass(UpdatePasswordController).singleton(),
       })
       .register({
         createProductService: asClass(CreateProductService).singleton(),

--- a/ims-backend/src/apps/core/routes/api/authentication.route.ts
+++ b/ims-backend/src/apps/core/routes/api/authentication.route.ts
@@ -1,10 +1,23 @@
 import { Express } from 'express';
 import AuthenticationController from '../../../ims/api/infrastructure/express/controllers/AuthenticationController';
 import Container from '../../di/Container';
+import UpdatePasswordController from '../../../ims/api/infrastructure/express/controllers/UpdatePasswordController';
 
 export const register = function (app: Express): void {
-  const controller: AuthenticationController = new Container()
-    .invoke()
-    .resolve<AuthenticationController>('authenticationController');
-  app.post('/auth/login', controller.rules, controller.invoke.bind(controller));
+  const container = new Container().invoke();
+  const authenticationController: AuthenticationController =
+    container.resolve<AuthenticationController>('authenticationController');
+  const updatePasswordController: UpdatePasswordController =
+    container.resolve<UpdatePasswordController>('updatePasswordController');
+  app.post(
+    '/auth/login',
+    authenticationController.rules,
+    authenticationController.invoke.bind(authenticationController),
+  );
+
+  app.put(
+    '/auth/password',
+    updatePasswordController.rules,
+    updatePasswordController.invoke.bind(updatePasswordController),
+  );
 };

--- a/ims-backend/src/apps/ims/api/application/authentication/AuthenticationService.ts
+++ b/ims-backend/src/apps/ims/api/application/authentication/AuthenticationService.ts
@@ -1,5 +1,6 @@
 import { Logger } from '../../../shared/domain/Logger';
 import { Authenticator } from '../../domain/authentication/Authenticator';
+import { User } from '../../domain/models/authentication/User';
 
 export type AuthenticationRequest = {
   email: string;
@@ -9,6 +10,7 @@ export type AuthenticationRequest = {
 export type AuthenticationResponse = {
   accessToken: string;
   expiresIn: number | string;
+  data: Omit<User, 'password'>;
 };
 
 export default class AuthenticationService {

--- a/ims-backend/src/apps/ims/api/application/authentication/UpdatePasswordService.ts
+++ b/ims-backend/src/apps/ims/api/application/authentication/UpdatePasswordService.ts
@@ -1,0 +1,27 @@
+import { Logger } from '../../../shared/domain/Logger';
+import { PasswordUpdater } from '../../domain/authentication/PasswordUpdater';
+import { User } from '../../domain/models/authentication/User';
+
+export type UpdatePasswordRequest = {
+  email: string;
+  password: string;
+  confirmPassword: string;
+};
+
+export type UpdatePasswordResponse = {
+  message: string;
+  code: number;
+  data: Omit<User, 'password'>;
+};
+
+export default class UpdatePasswordService {
+  constructor(
+    private logger: Logger,
+    private passwordUpdater: PasswordUpdater,
+  ) {}
+
+  public async invoke(request: UpdatePasswordRequest): Promise<UpdatePasswordResponse> {
+    this.logger.info(`User password update attempt using email: ${request.email}`);
+    return this.passwordUpdater.invoke(request);
+  }
+}

--- a/ims-backend/src/apps/ims/api/domain/authentication/PasswordUpdater.ts
+++ b/ims-backend/src/apps/ims/api/domain/authentication/PasswordUpdater.ts
@@ -1,0 +1,5 @@
+import { UpdatePasswordRequest, UpdatePasswordResponse } from '../../application/authentication/UpdatePasswordService';
+
+export interface PasswordUpdater {
+  invoke(request: UpdatePasswordRequest): Promise<UpdatePasswordResponse>;
+}

--- a/ims-backend/src/apps/ims/api/domain/models/authentication/User.ts
+++ b/ims-backend/src/apps/ims/api/domain/models/authentication/User.ts
@@ -6,4 +6,5 @@ export type User = {
   identification: string;
   phone: string;
   address: string;
+  password: string;
 };

--- a/ims-backend/src/apps/ims/api/domain/models/authentication/repositories/AuthenticationRepository.ts
+++ b/ims-backend/src/apps/ims/api/domain/models/authentication/repositories/AuthenticationRepository.ts
@@ -2,4 +2,5 @@ import { User } from '../User';
 
 export interface AuthenticationRepository {
   findByCredentials(email: string, password: string): Promise<User | null>;
+  updatePassword(email: string, password: string): Promise<User>;
 }

--- a/ims-backend/src/apps/ims/api/infrastructure/authentication/credentials/CredentialsAuthenticator.ts
+++ b/ims-backend/src/apps/ims/api/infrastructure/authentication/credentials/CredentialsAuthenticator.ts
@@ -20,10 +20,13 @@ export default class CredentialsAuthenticator implements Authenticator {
       throw new Error('Wrong credentials');
     }
 
-    const { accessToken, expiresIn }: AuthenticationResponse = this.jwtManager.generate(user);
+    // Ignore password field
+    const { password: _, ...userData } = user;
+    const { accessToken, expiresIn }: Omit<AuthenticationResponse, 'data'> = this.jwtManager.generate(userData);
     return {
       accessToken,
       expiresIn,
+      data: userData,
     };
   }
 }

--- a/ims-backend/src/apps/ims/api/infrastructure/authentication/credentials/CredentialsPasswordUpdater.ts
+++ b/ims-backend/src/apps/ims/api/infrastructure/authentication/credentials/CredentialsPasswordUpdater.ts
@@ -1,0 +1,30 @@
+import httpStatus from 'http-status';
+import {
+  UpdatePasswordRequest,
+  UpdatePasswordResponse,
+} from '../../../application/authentication/UpdatePasswordService';
+import { PasswordUpdater } from '../../../domain/authentication/PasswordUpdater';
+import { AuthenticationRepository } from '../../../domain/models/authentication/repositories/AuthenticationRepository';
+import { User } from '../../../domain/models/authentication/User';
+
+export default class CredentialsPasswordUpdater implements PasswordUpdater {
+  constructor(private readonly authenticationRepository: AuthenticationRepository) {}
+
+  public async invoke(request: UpdatePasswordRequest): Promise<UpdatePasswordResponse> {
+    // Check if passwords match
+    if (request.password !== request.confirmPassword) {
+      throw new Error('Passwords do not match');
+    }
+
+    // Ignore password field from response
+    const { password: _, ...user }: User = await this.authenticationRepository.updatePassword(
+      request.email,
+      request.password,
+    );
+    return {
+      message: 'Password updated',
+      code: httpStatus.OK,
+      data: user,
+    };
+  }
+}

--- a/ims-backend/src/apps/ims/api/infrastructure/authentication/repositories/PrismaAuthenticationRepository.ts
+++ b/ims-backend/src/apps/ims/api/infrastructure/authentication/repositories/PrismaAuthenticationRepository.ts
@@ -13,4 +13,15 @@ export default class PrismaAuthenticationRepository implements AuthenticationRep
       },
     });
   }
+
+  public async updatePassword(email: string, password: string): Promise<User> {
+    return await this.database.user.update({
+      where: {
+        email,
+      },
+      data: {
+        password,
+      },
+    });
+  }
 }

--- a/ims-backend/src/apps/ims/api/infrastructure/express/controllers/UpdatePasswordController.ts
+++ b/ims-backend/src/apps/ims/api/infrastructure/express/controllers/UpdatePasswordController.ts
@@ -1,0 +1,34 @@
+import type { Request, Response, NextFunction } from 'express';
+import status from 'http-status';
+import { Controller } from '../../../../shared/infrastructure/express/controllers/Controller';
+import { ErrorHandler } from '../../../../shared/domain/ErrorHandler';
+import { body } from 'express-validator';
+import { RequestValidator } from '../../../../shared/infrastructure/express/RequestValidator';
+import UpdatePasswordService, {
+  UpdatePasswordResponse,
+} from '../../../application/authentication/UpdatePasswordService';
+
+export default class UpdatePasswordController implements Controller {
+  public readonly rules = [
+    body('email').trim().normalizeEmail().isEmail().withMessage('Please give a valid email'),
+    body('password').trim().isLength({ min: 8 }).withMessage('Please give a valid password'),
+    body('confirmPassword').trim().isLength({ min: 8 }).withMessage('Please give a valid confirm password'),
+    RequestValidator,
+  ];
+
+  constructor(private updatePasswordService: UpdatePasswordService) {}
+
+  async invoke(request: Request, response: Response, next: NextFunction): Promise<Response | void> {
+    try {
+      const authenticationResponse: UpdatePasswordResponse = await this.updatePasswordService.invoke({
+        ...request.body,
+      });
+
+      response.json(authenticationResponse).status(status.OK);
+    } catch (error) {
+      const { message } = error as Error;
+      const errorHandler = new ErrorHandler(message, status.UNAUTHORIZED);
+      next(response.json(errorHandler.toJson()));
+    }
+  }
+}


### PR DESCRIPTION
### Related ticket

Ticket: [IMS-41: Create endpoint to change password](https://developer-solutions.atlassian.net/browse/IMS-41)

### Description

This PR added the endpoint to change the user password.

### Medias (if needed)

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/19d47465-3009-47d2-946f-1de446dccf3e">

### Testplan

- [x] I tested this change on my local environment.
- [ ] I ran the project using multiple simulators in Xcode.
- [ ] I ran the project using Real device (if applicable).
- [ ] I ran the unit tests.
- [x] I requested this endpoint on Postman (if applicable).
- [ ] I requested this endpoint on Swagger documentation (if applicable).

### Checklist

- [ ] I added tests for this change.
- [x] I checked the code style and run the linter.
- [ ] I added necessary documentation (if applicable).

