### PR TITLE
IMS-43: Add profile image with name abbreviations

### DIFF
--- a/ims-apple/IMS Apple/Utilities/Components/ProfileImage/ProfileImage.swift
+++ b/ims-apple/IMS Apple/Utilities/Components/ProfileImage/ProfileImage.swift
@@ -7,29 +7,47 @@
 
 import SwiftUI
 
+private enum Constants {
+    static let fontSize: CGFloat = 0.4
+    static let defaultSize: CGFloat = 40
+    static let namesPrefix: Int = 2
+    static let mapPrefix: Int = 1
+}
+
+// MARK: - Profile Image View
+
 struct ProfileImage: View {
-    private let url: String
+    private let fullName: String
     private let size: CGFloat
     
-    init(url: String, size: CGFloat = 40) {
-        self.url = url
+    init(fullName: String, 
+         size: CGFloat = Constants.defaultSize) {
+        self.fullName = fullName
         self.size = size
     }
     
     var body: some View {
-        AsyncImage(url: URL(string: url)) { image in
-            image
-                .resizable()
-                .frame(width: size, height: size)
-        } placeholder: {
-            Circle()
-                .fill(.graySecundary)
-                .frame(width: size)
-                .overlay(Image(systemName: "person.fill"))
-        }
+        Circle()
+            .fill(.imsLightPurple)
+            .frame(width: size)
+            .overlay {
+                Text(abbreviations)
+                    .font(.system(size: size * Constants.fontSize))
+                    .bold()
+            }
+    }
+    
+    private var abbreviations: String {
+        fullName
+            .split(separator: " ")
+            .prefix(Constants.namesPrefix)
+            .map { $0.prefix(Constants.mapPrefix) }
+            .joined()
+            .uppercased()
     }
 }
 
 #Preview {
-    ProfileImage(url: "https://pplam.png")
+    ProfileImage(fullName: "Juan Perez")
+        .padding()
 }

--- a/ims-apple/IMS Apple/Views/Main/MainView.swift
+++ b/ims-apple/IMS Apple/Views/Main/MainView.swift
@@ -60,7 +60,7 @@ struct MainView: View {
         Button {
             
         } label: {
-            ProfileImage(url: "https://pplam.png")
+            ProfileImage(fullName: "Juan Perez")
         }
         .buttonStyle(.plain)
     }

--- a/ims-apple/IMS Apple/Views/Users/UserListView.swift
+++ b/ims-apple/IMS Apple/Views/Users/UserListView.swift
@@ -78,7 +78,7 @@ struct UserListView: View {
             LazyVGrid(columns: columns) {
                 ForEach(UserModel.mockUsers) { user in
                     HStack {
-                        ProfileImage(url: user.image)
+                        ProfileImage(fullName: user.name)
                         
                         Text(user.name)
                             .fontWeight(.semibold)


### PR DESCRIPTION
### Related ticket

Ticket: [IMS-43: Add profile image with name abbreviations](https://developer-solutions.atlassian.net/browse/IMS-43)

### Description

- The profile image was removed
- Abbreviation name added

### Medias (if needed)

<img width="684" alt="image" src="https://github.com/user-attachments/assets/655068e9-a65e-4a77-ad5d-647caed459e1">

### Testplan

- [x] I tested this change on my local environment.
- [x] I ran the project using multiple simulators in Xcode.
- [x] I ran the project using Real device (if applicable).
- [ ] I ran the unit tests.
- [ ] I requested this endpoint on Postman (if applicable).
- [ ] I requested this endpoint on Swagger documentation (if applicable).

### Checklist

- [ ] I added tests for this change.
- [x] I checked the code style and run the linter.
- [ ] I added necessary documentation (if applicable).

