### PR TITLE
IMS-55: Remove Supply Product section

### DIFF
--- a/ims-apple/IMS Apple/Utilities/Components/Sidebar/SidebarItem.swift
+++ b/ims-apple/IMS Apple/Utilities/Components/Sidebar/SidebarItem.swift
@@ -13,7 +13,6 @@ enum SidebarItem {
     
     case productList
     case addProduct
-    case supplyProduct
     
     case invoiceSale
     case salesHistory
@@ -25,7 +24,6 @@ enum SidebarItem {
             
         case .productList: "Lista de productos"
         case .addProduct: "Agregar producto"
-        case .supplyProduct: "Abastecer producto"
             
         case .invoiceSale: "Facturar venta"
         case .salesHistory: "Historial de ventas"
@@ -38,7 +36,6 @@ enum SidebarItem {
         case .users: "person"
         case .productList: "list.bullet.rectangle.portrait"
         case .addProduct: "plus.circle"
-        case .supplyProduct: "arrow.2.circlepath"
         case .invoiceSale: "plus.circle"
         case .salesHistory: "doc.text.magnifyingglass"
         }

--- a/ims-apple/IMS Apple/Utilities/Components/Sidebar/SidebarSection.swift
+++ b/ims-apple/IMS Apple/Utilities/Components/Sidebar/SidebarSection.swift
@@ -23,7 +23,7 @@ enum SidebarSection: CaseIterable {
     var itemList: [SidebarItem] {
         switch self {
         case .dashboard: [.graphs, .users]
-        case .inventory: [.productList, .addProduct, .supplyProduct]
+        case .inventory: [.productList, .addProduct]
         case .invoicing: [.invoiceSale, .salesHistory]
         }
     }

--- a/ims-apple/IMS Apple/Views/Products/ProductList/ProductListView.swift
+++ b/ims-apple/IMS Apple/Views/Products/ProductList/ProductListView.swift
@@ -31,7 +31,7 @@ private enum Constants {
 
 struct ProductListView: View {
     @ObservedObject private var viewModel: ProductListViewModel = .init()
-    private let adaptiveColumn = [GridItem(.adaptive(minimum: Constants.gridMinimum))]
+    private let adaptiveColumn = [GridItem(.adaptive(minimum: Constants.gridMinimum), spacing: Constants.padding)]
     
     var body: some View {
         ScrollView(showsIndicators: false) {
@@ -98,7 +98,7 @@ struct ProductListView: View {
             Spacer()
         }
         .padding([.top, .horizontal], Constants.padding)
-        .frame(width: Constants.cardWidth, height: Constants.cardHeight)
+        .frame(maxWidth: .infinity, maxHeight: Constants.cardHeight)
         .background(.secondaryBackground)
         .overlay(alignment: .topTrailing) {
             amountBanner(amount: product.amount)


### PR DESCRIPTION
### Related ticket

Ticket: [IMS-55: Remove Supply Product section](https://developer-solutions.atlassian.net/browse/IMS-55)

### Description

- Supply product section was removed
- Now the user can be supply some product clicking product card

### Medias (if needed)

- NONE

### Testplan

- [x] I tested this change on my local environment.
- [x] I ran the project using multiple simulators in Xcode.
- [x] I ran the project using Real device (if applicable).
- [ ] I ran the unit tests.
- [ ] I requested this endpoint on Postman (if applicable).
- [ ] I requested this endpoint on Swagger documentation (if applicable).

### Checklist

- [ ] I added tests for this change.
- [x] I checked the code style and run the linter.
- [ ] I added necessary documentation (if applicable).

