### PR TITLE
IMS-56: Create endpoint to get the count product

### DIFF
--- a/ims-backend/src/apps/core/di/Container.ts
+++ b/ims-backend/src/apps/core/di/Container.ts
@@ -28,6 +28,9 @@ import AssignRoleController from '../../ims/api/infrastructure/express/controlle
 import AssignRoleService from '../../ims/api/application/rbac/AssignRoleService';
 import RoleAssigner from '../../ims/api/infrastructure/rbac/RoleAssigner';
 import PrismaRbacRepository from '../../ims/api/infrastructure/rbac/repositories/PrismaRbacRepository';
+import ProductCounter from '../../ims/api/infrastructure/products/ProductCounter';
+import CountProductController from '../../ims/api/infrastructure/express/controllers/products/CountProductController';
+import CountProductService from '../../ims/api/application/products/CountProductService';
 
 export default class Container {
   private readonly container: AwilixContainer;
@@ -67,15 +70,18 @@ export default class Container {
         fetchProductService: asClass(FetchProductService).singleton(),
         removeProductService: asClass(RemoveProductService).singleton(),
         supplyProductService: asClass(SupplyProductService).singleton(),
+        countProductService: asClass(CountProductService).singleton(),
         productCreator: asClass(ProductCreator).singleton(),
         productFetcher: asClass(ProductFetcher).singleton(),
         productRemover: asClass(ProductRemover).singleton(),
         productSupplier: asClass(ProductSupplier).singleton(),
+        productCounter: asClass(ProductCounter).singleton(),
         productRepository: asClass(PrismaProductRepository).singleton(),
         createProductController: asClass(CreateProductController).singleton(),
         fetchProductController: asClass(FetchProductController).singleton(),
         removeProductController: asClass(RemoveProductController).singleton(),
         supplyProductController: asClass(SupplyProductController).singleton(),
+        countProductController: asClass(CountProductController).singleton(),
       })
       .register({
         assignRoleController: asClass(AssignRoleController).singleton(),

--- a/ims-backend/src/apps/core/routes/api/products.route.ts
+++ b/ims-backend/src/apps/core/routes/api/products.route.ts
@@ -4,6 +4,7 @@ import CreateProductController from '../../../ims/api/infrastructure/express/con
 import FetchProductController from '../../../ims/api/infrastructure/express/controllers/products/FetchProductController';
 import RemoveProductController from '../../../ims/api/infrastructure/express/controllers/products/RemoveProductController';
 import SupplyProductController from '../../../ims/api/infrastructure/express/controllers/products/SupplyProductController';
+import CountProductController from '../../../ims/api/infrastructure/express/controllers/products/CountProductController';
 
 export const register = function (app: Express): void {
   const container = new Container().invoke();
@@ -14,8 +15,10 @@ export const register = function (app: Express): void {
     container.resolve<RemoveProductController>('removeProductController');
   const supplyController: SupplyProductController =
     container.resolve<SupplyProductController>('supplyProductController');
+  const countController: CountProductController = container.resolve<CountProductController>('countProductController');
 
   app.get('/products', fetchController.invoke.bind(fetchController));
+  app.get('/products/count', countController.invoke.bind(countController));
   app.post('/products', createController.rules, createController.invoke.bind(createController));
   app.put('/products', supplyController.rules, supplyController.invoke.bind(supplyController));
   app.delete('/products', removeController.rules, removeController.invoke.bind(removeController));

--- a/ims-backend/src/apps/ims/api/application/products/CountProductService.ts
+++ b/ims-backend/src/apps/ims/api/application/products/CountProductService.ts
@@ -1,0 +1,19 @@
+import { Logger } from '../../../shared/domain/Logger';
+import { Counter } from '../../domain/products/Counter';
+
+export type CountProductResponse = {
+  message: string;
+  data: { quantity: number };
+};
+
+export default class CountProductService {
+  constructor(
+    private readonly logger: Logger,
+    private readonly productCounter: Counter,
+  ) {}
+
+  public async invoke(): Promise<CountProductResponse> {
+    this.logger.info('Counting products');
+    return this.productCounter.invoke();
+  }
+}

--- a/ims-backend/src/apps/ims/api/domain/models/products/repositories/ProductRepository.ts
+++ b/ims-backend/src/apps/ims/api/domain/models/products/repositories/ProductRepository.ts
@@ -2,4 +2,5 @@ import { Product } from '../Product';
 
 export interface ProductRepository {
   supply(id: number, stock: number): Promise<Product>;
+  count(): Promise<number>;
 }

--- a/ims-backend/src/apps/ims/api/domain/products/Counter.ts
+++ b/ims-backend/src/apps/ims/api/domain/products/Counter.ts
@@ -1,0 +1,5 @@
+import { CountProductResponse } from '../../application/products/CountProductService';
+
+export interface Counter {
+  invoke(): Promise<CountProductResponse>;
+}

--- a/ims-backend/src/apps/ims/api/infrastructure/express/controllers/products/CountProductController.ts
+++ b/ims-backend/src/apps/ims/api/infrastructure/express/controllers/products/CountProductController.ts
@@ -1,0 +1,20 @@
+import { NextFunction, Request, Response } from 'express';
+import status from 'http-status';
+import { Controller } from '../../../../../shared/infrastructure/express/controllers/Controller';
+import { ErrorHandler } from '../../../../../shared/domain/ErrorHandler';
+import CountProductService, { CountProductResponse } from '../../../../application/products/CountProductService';
+
+export default class CountProductController implements Controller {
+  constructor(private readonly countProductService: CountProductService) {}
+
+  async invoke(_: Request, response: Response, next: NextFunction): Promise<Response | void> {
+    try {
+      const productResponse: CountProductResponse = await this.countProductService.invoke();
+      return response.json(productResponse).status(status.OK);
+    } catch (error) {
+      const { message } = error as Error;
+      const errorHandler = new ErrorHandler(message, status.INTERNAL_SERVER_ERROR);
+      next(response.json(errorHandler.toJson()));
+    }
+  }
+}

--- a/ims-backend/src/apps/ims/api/infrastructure/products/ProductCounter.ts
+++ b/ims-backend/src/apps/ims/api/infrastructure/products/ProductCounter.ts
@@ -1,0 +1,15 @@
+import { CountProductResponse } from '../../application/products/CountProductService';
+import { ProductRepository } from '../../domain/models/products/repositories/ProductRepository';
+import { Counter } from '../../domain/products/Counter';
+
+export default class ProductCounter implements Counter {
+  constructor(private readonly productRepository: ProductRepository) {}
+
+  async invoke(): Promise<CountProductResponse> {
+    const productsCount: number = await this.productRepository.count();
+    return {
+      message: 'Products counted',
+      data: { quantity: productsCount },
+    };
+  }
+}

--- a/ims-backend/src/apps/ims/api/infrastructure/products/repositories/PrismaProductRepository.ts
+++ b/ims-backend/src/apps/ims/api/infrastructure/products/repositories/PrismaProductRepository.ts
@@ -62,4 +62,8 @@ export default class PrismaProductRepository implements ProductRepository, CrudR
       },
     });
   }
+
+  async count(): Promise<number> {
+    return await this.database.product.count();
+  }
 }


### PR DESCRIPTION
### Related ticket

Ticket: [IMS-56: Create endpoint to get the count product](https://developer-solutions.atlassian.net/browse/IMS-56)

### Description

This PR added the endpoint to get the products count.

- Added the product counter service.
- Added the product counter controller.

### Medias (if needed)

<img width="988" alt="image" src="https://github.com/user-attachments/assets/df1eb9b4-5c0a-49db-8d4c-88b1455c4877">

### Testplan

- [x] I tested this change on my local environment.
- [ ] I ran the project using multiple simulators in Xcode.
- [ ] I ran the project using Real device (if applicable).
- [ ] I ran the unit tests.
- [x] I requested this endpoint on Postman (if applicable).
- [ ] I requested this endpoint on Swagger documentation (if applicable).

### Checklist

- [ ] I added tests for this change.
- [x] I checked the code style and run the linter.
- [x] I added necessary documentation (if applicable).

